### PR TITLE
fix(scalability): prevent OOM errors with large databases

### DIFF
--- a/actions/repair.php
+++ b/actions/repair.php
@@ -7,92 +7,13 @@
  * @copyright Cash Costello 2010-2014
  */
 
-/*
- * Yes, these chunks of html creation could be moved to views.
- */
-
 set_time_limit(0);
 
-// this is needed for calling get_user() on disabled users.
-$access_status = access_get_show_hidden_status();
-access_show_hidden_entities(true);
 
 $db_prefix = elgg_get_config('dbprefix');
 
-$users = dbvalidate_get_bad_users();
-
-// repair bad users - give them new usernames
-if ($users !== false && count($users) > 0) {
-	$user_count = 1;
-	echo elgg_echo('dbvalidate:fixbadusernames');
-	echo "<ul>";
-	foreach ($users as $user) {
-		// create new username
-		$new_username = 'user' . $user_count;
-		$user_count = $user_count + 1;
-		while (!dbvalidate_test_username_avail($new_username)) {
-			$new_username = 'user' . $user_count;
-			$user_count = $user_count + 1;
-		}
-		$entity = get_user($user->guid);
-		$entity->username = $new_username;
-		$entity->save();
-		echo "<li>" . elgg_echo('dbvalidate:GUID') . $entity->guid . ' ' . elgg_echo('dbvalidate:USERNAME') . $entity->username . "</li>";
-	}
-	echo "</ul>";
-}
-
-echo "<br />";
-
-$bad_guids = dbvalidate_get_bad_entities();
-
-// write html for bad entities - they get assigned to admin running this
-if (count($bad_guids) > 0) {
-	$new_guid = elgg_get_logged_in_user_guid();
-	echo elgg_echo('dbvalidate:fixbadowners');
-	echo "<ul>";
-	foreach ($bad_guids as $guid) {
-		$query = "UPDATE {$db_prefix}entities set owner_guid={$new_guid} WHERE guid={$guid}";
-		$ret = update_data($query);
-		echo "<li>";
-		if ($ret) {
-			echo elgg_echo('dbvalidate:GUID') . $guid . " - " . elgg_echo('dbvalidate:newowner');
-		} else {
-			echo elgg_echo('dbvalidate:GUID') . $guid . " - " . elgg_echo('dbvalidate:failowner');
-		}
-		echo "</li>";
-	}
-	echo "</ul>";
-}
-
-echo "<br />";
-
-$incomplete_entities = dbvalidate_get_incomplete_entities();
-
-// write html for incomplete entities - delete them
-if ($incomplete_entities !== false && count($incomplete_entities) > 0) {
-	echo elgg_echo('dbvalidate:fixincompleteentities');
-	echo "<ul>";
-	foreach ($incomplete_entities as $entity) {
-		echo "<li>";
-		echo elgg_echo('dbvalidate:GUID') . $entity->guid . ", " . elgg_echo('dbvalidate:type') . ": " .$entity->type;
-		if ($subtype = get_subtype_from_id($entity->subtype)) {
-			echo ":$subtype";
-		}
-		$query = "DELETE FROM {$db_prefix}entities WHERE guid = {$entity->guid} LIMIT 1";
-		if (delete_data($query)) {
-			echo ' ' . elgg_echo('dbvalidate:removed');
-		}
-
-		echo "</li>";
-	}
-	echo "</ul>";
-}
-
-echo "<br />";
-
-access_show_hidden_entities($access_status);
-
-echo elgg_echo('dbvalidate:done');
-
+dbvalidate_fix_bad_users();
+dbvalidate_fix_incomplete_entities();
+dbvalidate_fix_bad_entities();
+echo 'done';
 exit;

--- a/actions/validate.php
+++ b/actions/validate.php
@@ -11,17 +11,14 @@ set_time_limit(0);
 
 echo "<h3>" . elgg_echo('dbvalidate:users') . "</h3>";
 
-$users = dbvalidate_get_bad_users();
+$users = dbvalidate_count_bad_users();
 
 // write html for bad users
-if ($users !== false && count($users) > 0) {
-	echo elgg_echo('dbvalidate:badusernames');
+if ($users) {
 	echo "<ul>";
-	foreach ($users as $user) {
 		echo "<li>";
-		echo elgg_echo('dbvalidate:GUID') . $user->guid;
+		echo elgg_echo('dbvalidate:badusers:count', array($users));
 		echo "</li>";
-	}
 	echo "</ul>";
 } else {
 	echo elgg_echo('dbvalidate:nobadusernames');
@@ -32,17 +29,29 @@ echo "<br />";
 
 echo "<h3>" . elgg_echo('dbvalidate:entities') . "</h3>";
 
-$bad_guids = dbvalidate_get_bad_entities();
+
+$incomplete_entities = dbvalidate_count_incomplete_entities();
+
+// write html for incomplete entities
+if ($incomplete_entities) {
+	echo "<ul>";
+		echo "<li>";
+		echo elgg_echo('dbvalidate:incomplete_entities:count', array($incomplete_entities));
+		echo "</li>";
+	echo "</ul>";
+} else {
+	echo elgg_echo('dbvalidate:noincompleteentities');
+	echo "<br />";
+}
+
+$entities = dbvalidate_count_bad_entities();
 
 // write html for bad entities
-if (count($bad_guids) > 0) {
-	echo elgg_echo('dbvalidate:badowners');
+if ($entities) {
 	echo "<ul>";
-	foreach ($bad_guids as $guid) {
 		echo "<li>";
-		echo elgg_echo('dbvalidate:GUID') . $guid . ", " . elgg_echo('dbvalidate:type') . ': ' . dbvalidate_get_object_type($guid);
+		echo elgg_echo('dbvalidate:badentities:count', array($entities));
 		echo "</li>";
-	}
 	echo "</ul>";
 } else {
 	echo elgg_echo('dbvalidate:nobadowners');
@@ -50,24 +59,5 @@ if (count($bad_guids) > 0) {
 
 echo "<br />";
 
-$incomplete_entities = dbvalidate_get_incomplete_entities();
-
-// write html for incomplete entities
-if ($incomplete_entities !== false && count($incomplete_entities) > 0) {
-	echo elgg_echo('dbvalidate:incompleteentities');
-	echo "<ul>";
-	foreach ($incomplete_entities as $entity) {
-		echo "<li>";
-		echo elgg_echo('dbvalidate:GUID') . $entity->guid . ", " . elgg_echo('dbvalidate:type') . ": " .$entity->type;
-		if ($subtype = get_subtype_from_id($entity->subtype)) {
-			echo ":$subtype";
-		}
-		echo "</li>";
-	}
-	echo "</ul>";
-} else {
-	echo elgg_echo('dbvalidate:noincompleteentities');
-	echo "<br />";
-}
 
 exit;

--- a/languages/en.php
+++ b/languages/en.php
@@ -6,6 +6,9 @@
 return array(
 
 	'admin:administer_utilities:dbvalidate' => "Database cleaner",
+	'dbvalidate:badusers:count' => "There are %s users without usernames",
+	'dbvalidate:badentities:count' => "There are %s bad entities without owners",
+	'dbvalidate:incomplete_entities:count' => "There are %s incomplete entities",
 
 	'dbvalidate:title' => "Database utility",
 	'dbvalidate:validate' => "Validate",

--- a/manifest.xml
+++ b/manifest.xml
@@ -3,7 +3,7 @@
 	<name>Database Cleaner</name>
 	<id>dbvalidator</id>
 	<author>Cash Costello</author>
-	<version>1.5</version>
+	<version>2.0</version>
 	<category>admin</category>
 	<category>utility</category>
 	<description>Repairs issues in the database.</description>

--- a/views/default/js/dbvalidate.php
+++ b/views/default/js/dbvalidate.php
@@ -19,6 +19,7 @@ elgg.dbvalidate.submit = function(event) {
 	// actions in Elgg send back json so we use $.ajax
 	$.ajax({
 		type: "GET",
+		timeout: 3600000,
 		url: $(this).attr('href'),
 		dataType: "html",
 		success: function(htmlData) {
@@ -27,6 +28,10 @@ elgg.dbvalidate.submit = function(event) {
 			if (htmlData.length > 0) {
 				$("#dbv-results").html(htmlData);
 			}
+		},
+		error: function(jqXHR, textStatus, error) {
+			$("dbv-ajax-spinner").hide();
+			$("#dbv-results").html(textStatus);
 		}
 	});
 


### PR DESCRIPTION
Currently with large databases with a fair amount of corruption this plugin causes OOM errors and cannot fix anything.  This is due to it trying to generate html and store it in memory while searching for broken entities.

This fixes that by removing the html generation and simply showing a count of each type of broken entity and a batch script for cleaning it up.